### PR TITLE
Enable book picture deletion

### DIFF
--- a/app/src/main/java/com/example/bookwormadventuresdeluxe2/AddOrEditBooksActivity.java
+++ b/app/src/main/java/com/example/bookwormadventuresdeluxe2/AddOrEditBooksActivity.java
@@ -178,6 +178,8 @@ public class AddOrEditBooksActivity extends AppCompatActivity
             throw new IllegalStateException("deletePhoto should not have been called!");
         }
 
+        // Remove the association to the book object
+        this.bookPhotoDowloadUrl = "";
         // Delete image from firebase
         this.deletePhotoFromFirebase(imageUrl);
     }

--- a/app/src/main/java/com/example/bookwormadventuresdeluxe2/AddOrEditBooksActivity.java
+++ b/app/src/main/java/com/example/bookwormadventuresdeluxe2/AddOrEditBooksActivity.java
@@ -32,6 +32,7 @@ import com.example.bookwormadventuresdeluxe2.Utilities.Status;
 import com.example.bookwormadventuresdeluxe2.Utilities.UserCredentialAPI;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.storage.FirebaseStorage;
@@ -50,7 +51,9 @@ public class AddOrEditBooksActivity extends AppCompatActivity
     ImageView bookPicture;
     EditText titleView, authorView, descriptionView, isbnView;
     boolean editingBook = false;
+    boolean deleteBookPictureWhenSaving = false;
     Button deleteButton;
+    FloatingActionButton deletePictureButton;
     Book bookToEdit;
     String bookPhotoDowloadUrl = "";
 
@@ -73,6 +76,7 @@ public class AddOrEditBooksActivity extends AppCompatActivity
         descriptionView = findViewById(R.id.description_edit_text);
         isbnView = findViewById(R.id.isbn_edit_text);
         deleteButton = findViewById(R.id.delete_button);
+        deletePictureButton = findViewById(R.id.delete_picture);
         bookPicture = findViewById(R.id.book_photo);
 
         /* If editing a book, prepopulate text fields with their old values */
@@ -96,10 +100,41 @@ public class AddOrEditBooksActivity extends AppCompatActivity
             }
         }
 
-        /* Hide the delete button if we are adding a book */
-        if (!this.editingBook)
+        /* When the user clicks on the delete button
+         * Remove picture from screen and hide the delete button
+         * This is necessary for when the user cancels editing the book*/
+        deletePictureButton.setOnClickListener(new View.OnClickListener()
         {
+            @Override
+            public void onClick(View view)
+            {
+                // will be checked when the user saves
+                deleteBookPictureWhenSaving = true;
+                // remove the picture from the screen
+                bookPicture.setImageResource(R.drawable.ic_camera);
+                // Hide the delete picture button
+                deletePictureButton.hide();
+            }
+        });
+
+        if (this.editingBook)
+        {
+            /* Hide delete button if the book has no image url*/
+            if (bookToEdit.getImageUrl().equals(""))
+            {
+                deletePictureButton.hide();
+            }
+            else
+            {
+                /* Only show the delete button if we are editing a book and it has an image*/
+                deletePictureButton.show();
+            }
+        }
+        else
+        {
+            /* Hide the delete button if we are adding a book */
             deleteButton.setVisibility(View.INVISIBLE);
+            deletePictureButton.hide();
         }
     }
 
@@ -118,6 +153,51 @@ public class AddOrEditBooksActivity extends AppCompatActivity
         startActivityForResult(Intent.createChooser(uploadPhotoIntent, getResources().getString(R.string.select_photo)), REQUEST_IMAGE_UPLOAD);
     }
 
+    /**
+     * Deletes the picture associated with the book being edited
+     */
+    private void deletePhoto()
+    {
+        String imageUrl;
+        if (editingBook)
+        {
+            imageUrl = this.bookToEdit.getImageUrl();
+            // remove association of book to the image url
+            this.bookToEdit.setImageUrl("");
+        }
+        else
+        {
+            /* This will occur when a user uploads a picture
+             * when adding a new book then deletes it before saving the new book*/
+            imageUrl = this.bookPhotoDowloadUrl;
+        }
+
+        /* This should never be called when the book does not have an image*/
+        if (imageUrl.equals(""))
+        {
+            throw new IllegalStateException("deletePhoto should not have been called!");
+        }
+
+        // Delete image from firebase
+        FirebaseStorage storage = FirebaseStorage.getInstance();
+        StorageReference currentBookPhoto = storage.getReferenceFromUrl(imageUrl);
+        currentBookPhoto.delete().addOnSuccessListener(new OnSuccessListener<Void>()
+        {
+            @Override
+            public void onSuccess(Void aVoid)
+            {
+                // File deleted successfully
+            }
+        }).addOnFailureListener(new OnFailureListener()
+        {
+            @Override
+            public void onFailure(@NonNull Exception exception)
+            {
+                /* Should delete manually from firebase */
+                Log.v("deletePhoto", "Old photo was not deleted");
+            }
+        });
+    }
 
     /**
      * Returns the new or edited book to the activity that called EditBooksActivity
@@ -136,6 +216,12 @@ public class AddOrEditBooksActivity extends AppCompatActivity
 
         if (fieldsValid())
         {
+            if (this.deleteBookPictureWhenSaving)
+            {
+                // commit the changes to Firebase and the book object
+                this.deletePhoto();
+            }
+
             if (editingBook)
             {
                 // Update the book and send it back to the calling fragment, MyBooksDetailViewFragment
@@ -256,6 +342,9 @@ public class AddOrEditBooksActivity extends AppCompatActivity
         if (requestCode == REQUEST_IMAGE_UPLOAD && resultCode == RESULT_OK)
         {
             uploadPhoto(intent.getData());
+            deletePictureButton.show();
+            // if the user uploads a picture, reassign this to false
+            this.deleteBookPictureWhenSaving = false;
         }
         else
         {

--- a/app/src/main/java/com/example/bookwormadventuresdeluxe2/AddOrEditBooksActivity.java
+++ b/app/src/main/java/com/example/bookwormadventuresdeluxe2/AddOrEditBooksActivity.java
@@ -179,24 +179,7 @@ public class AddOrEditBooksActivity extends AppCompatActivity
         }
 
         // Delete image from firebase
-        FirebaseStorage storage = FirebaseStorage.getInstance();
-        StorageReference currentBookPhoto = storage.getReferenceFromUrl(imageUrl);
-        currentBookPhoto.delete().addOnSuccessListener(new OnSuccessListener<Void>()
-        {
-            @Override
-            public void onSuccess(Void aVoid)
-            {
-                // File deleted successfully
-            }
-        }).addOnFailureListener(new OnFailureListener()
-        {
-            @Override
-            public void onFailure(@NonNull Exception exception)
-            {
-                /* Should delete manually from firebase */
-                Log.v("deletePhoto", "Old photo was not deleted");
-            }
-        });
+        this.deletePhotoFromFirebase(imageUrl);
     }
 
     /**
@@ -411,6 +394,34 @@ public class AddOrEditBooksActivity extends AppCompatActivity
     }
 
     /**
+     * Deletes the linked photo from Firebase
+     *
+     * @param imageUrl
+     */
+    private void deletePhotoFromFirebase(String imageUrl)
+    {
+        // https://stackoverflow.com/questions/45103085/deleting-file-from-firebase-storage-using-url
+        FirebaseStorage storage = FirebaseStorage.getInstance();
+        StorageReference currentBookPhoto = storage.getReferenceFromUrl(imageUrl);
+        currentBookPhoto.delete().addOnSuccessListener(new OnSuccessListener<Void>()
+        {
+            @Override
+            public void onSuccess(Void aVoid)
+            {
+                // File deleted successfully
+            }
+        }).addOnFailureListener(new OnFailureListener()
+        {
+            @Override
+            public void onFailure(@NonNull Exception exception)
+            {
+                /* Should delete manually from firebase */
+                Log.v("uploadPhoto", "Old photo was not deleted");
+            }
+        });
+    }
+
+    /**
      * Uploads the selected image to FireStorage and updates the view with the
      * chosen image on success
      *
@@ -424,24 +435,7 @@ public class AddOrEditBooksActivity extends AppCompatActivity
         /* If the book already has a photo, we want to delete it before adding a new one */
         if (this.bookToEdit != null && this.bookToEdit.getImageUrl().compareTo("") != 0)
         {
-            StorageReference currentBookPhoto = storage.getReferenceFromUrl(this.bookToEdit.getImageUrl());
-            // https://stackoverflow.com/questions/45103085/deleting-file-from-firebase-storage-using-url
-            currentBookPhoto.delete().addOnSuccessListener(new OnSuccessListener<Void>()
-            {
-                @Override
-                public void onSuccess(Void aVoid)
-                {
-                    // File deleted successfully
-                }
-            }).addOnFailureListener(new OnFailureListener()
-            {
-                @Override
-                public void onFailure(@NonNull Exception exception)
-                {
-                    /* Should delete manually from firebase */
-                    Log.v("uploadPhoto", "Old photo was not deleted");
-                }
-            });
+            this.deletePhotoFromFirebase(this.bookToEdit.getImageUrl());
         }
 
         // https://code.tutsplus.com/tutorials/image-upload-to-firebase-in-android-application--cms-29934

--- a/app/src/main/res/drawable/ic_delete.xml
+++ b/app/src/main/res/drawable/ic_delete.xml
@@ -1,0 +1,4 @@
+<vector android:height="32dp" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="32dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#ffffff" android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2L18,7L6,7v12zM8,9h8v10L8,19L8,9zM15.5,4l-1,-1h-5l-1,1L5,4v2h14L19,4z"/>
+</vector>

--- a/app/src/main/res/layout/activity_edit_books.xml
+++ b/app/src/main/res/layout/activity_edit_books.xml
@@ -23,6 +23,21 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/delete_picture"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/edit_page_delete_picture_button"
+            android:onClick="deletePhoto"
+            android:src="@drawable/ic_delete"
+            app:backgroundTint="@color/delete"
+            app:borderWidth="0dp"
+            app:layout_constraintBottom_toBottomOf="@+id/book_photo"
+            app:layout_constraintEnd_toEndOf="@+id/book_photo"
+            app:layout_constraintStart_toStartOf="@+id/book_photo"
+            app:layout_constraintTop_toTopOf="@+id/book_photo"
+            app:tint="@android:color/white" />
+
         <TextView
             android:id="@+id/take_photo"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_edit_books.xml
+++ b/app/src/main/res/layout/activity_edit_books.xml
@@ -28,7 +28,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:contentDescription="@string/edit_page_delete_picture_button"
-            android:onClick="deletePhoto"
             android:src="@drawable/ic_delete"
             app:backgroundTint="@color/delete"
             app:borderWidth="0dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="navbar_text_label_3">Requests</string>
     <string name="navbar_text_label_4">Profile</string>
     <string name="fab_content_desc">Add Book</string>
+    <string name="edit_page_delete_picture_button">Delete Picture</string>
     <string name="my_requests">My Requests</string>
     <string name="borrow">Borrow</string>
     <string name="set_location">Set Pickup Location</string>


### PR DESCRIPTION
![Screenshot_20201103-131412_Bookworm_Adventures_Deluxe_2](https://user-images.githubusercontent.com/43558584/98036035-93836200-1dd6-11eb-9282-352f7e90741f.jpg)

Important thing to note here is that the actual book deletion only occurs when the user saves the book. If the user cancels the edit of the book, the image information of the book does not change.

There's some parts where the code looks clunky but it is for a reason. For most of them, I put the reason as comments. If anything is unclear, please let me know so I can clarify.