### PR TITLE
Fix text size for set pickup location after removing all caps

### DIFF
--- a/app/src/main/res/layout/activity_set_location.xml
+++ b/app/src/main/res/layout/activity_set_location.xml
@@ -41,7 +41,7 @@
         android:backgroundTint="@color/colorPrimary"
         android:text="@string/set_location"
         android:textColor="@color/colorBackground"
-        android:textSize="24dp"
+        android:textSize="20dp"
         app:layout_constraintTop_toBottomOf="@+id/address_search_view"
         tools:layout_editor_absoluteX="36dp" />
 


### PR DESCRIPTION
Before it used to spill outside of the button
![image](https://user-images.githubusercontent.com/44733046/100530172-d523e480-31ab-11eb-959a-29a32f52898c.png)
