### PR TITLE
Closing detail fragments - Disable edit if not available

### DIFF
--- a/app/src/main/java/com/example/bookwormadventuresdeluxe2/Activities/AddOrEditBooksActivity.java
+++ b/app/src/main/java/com/example/bookwormadventuresdeluxe2/Activities/AddOrEditBooksActivity.java
@@ -154,15 +154,18 @@ public class AddOrEditBooksActivity extends AppCompatActivity
                 takePhoto.setVisibility(View.GONE);
                 scanIsbnButton.setVisibility(View.GONE);
             }
-            /* Hide delete button if the book has no image url*/
-            if (bookToEdit.getImageUrl().equals(""))
-            {
-                deletePictureButton.hide();
-            }
             else
             {
-                /* Only show the delete button if we are editing a book and it has an image*/
-                deletePictureButton.show();
+                /* Hide delete button if the book has no image url*/
+                if (bookToEdit.getImageUrl().equals(""))
+                {
+                    deletePictureButton.hide();
+                }
+                else
+                {
+                    /* Only show the delete button if we are editing a book and it has an image*/
+                    deletePictureButton.show();
+                }
             }
         }
         else

--- a/app/src/main/java/com/example/bookwormadventuresdeluxe2/Activities/AddOrEditBooksActivity.java
+++ b/app/src/main/java/com/example/bookwormadventuresdeluxe2/Activities/AddOrEditBooksActivity.java
@@ -16,10 +16,8 @@ import android.os.Bundle;
 import android.provider.MediaStore;
 import android.text.TextUtils;
 import android.util.Log;
-import android.view.Gravity;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
@@ -58,17 +56,18 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.UUID;
 
 public class AddOrEditBooksActivity extends AppCompatActivity
 {
     private TextView takePhoto;
     private ImageView bookPicture;
+    private ImageView scanIsbnButton;
     private EditText titleView, authorView, descriptionView, isbnView;
     private boolean editingBook = false;
     private boolean deleteBookPictureWhenSaving = false;
     private Button deleteButton;
+    private FloatingActionButton saveButton;
     private FloatingActionButton deletePictureButton;
     private Book bookToEdit;
     private String bookPhotoDownloadUrl = "";
@@ -94,8 +93,10 @@ public class AddOrEditBooksActivity extends AppCompatActivity
         authorView = findViewById(R.id.author_edit_text);
         descriptionView = findViewById(R.id.description_edit_text);
         isbnView = findViewById(R.id.isbn_edit_text);
+        scanIsbnButton = findViewById(R.id.scan_isbn_button);
         deleteButton = findViewById(R.id.delete_button);
         deletePictureButton = findViewById(R.id.delete_picture);
+        saveButton = findViewById(R.id.my_books_save_button);
         bookPicture = findViewById(R.id.book_photo);
         requestQueue = Volley.newRequestQueue(this);
 
@@ -141,6 +142,18 @@ public class AddOrEditBooksActivity extends AppCompatActivity
 
         if (this.editingBook)
         {
+            /* Disable editing if book is not available */
+            if (!bookToEdit.getStatus().equals(Status.Available))
+            {
+                titleView.setFocusable(false);
+                authorView.setFocusable(false);
+                descriptionView.setFocusable(false);
+                isbnView.setFocusable(false);
+                deletePictureButton.hide();
+                saveButton.hide();
+                takePhoto.setVisibility(View.GONE);
+                scanIsbnButton.setVisibility(View.GONE);
+            }
             /* Hide delete button if the book has no image url*/
             if (bookToEdit.getImageUrl().equals(""))
             {
@@ -213,23 +226,6 @@ public class AddOrEditBooksActivity extends AppCompatActivity
      */
     public void saveBook(View view)
     {
-        /* Disable saving changes if book is not available */
-        if (this.editingBook
-                && Arrays.asList(Status.Requested,
-                                    Status.Accepted,
-                                    Status.bPending,
-                                    Status.Borrowed,
-                                    Status.rPending).contains(bookToEdit.getStatus()))
-        {
-            Toast toast = Toast.makeText(AddOrEditBooksActivity.this, getString(R.string.cannot_edit_book), Toast.LENGTH_LONG);
-            toast.setGravity(Gravity.CENTER_VERTICAL|Gravity.CENTER_HORIZONTAL, 0,0);
-            ViewGroup group = (ViewGroup) toast.getView();
-            TextView messageTextView = (TextView) group.getChildAt(0);
-            messageTextView.setTextSize(18);
-            toast.show();
-            return;
-        }
-
         /* Save changes */
         firebaseAuth = FirebaseAuth.getInstance();
         String title, author, description, isbn;

--- a/app/src/main/java/com/example/bookwormadventuresdeluxe2/Activities/AddOrEditBooksActivity.java
+++ b/app/src/main/java/com/example/bookwormadventuresdeluxe2/Activities/AddOrEditBooksActivity.java
@@ -16,8 +16,10 @@ import android.os.Bundle;
 import android.provider.MediaStore;
 import android.text.TextUtils;
 import android.util.Log;
+import android.view.Gravity;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
@@ -139,17 +141,6 @@ public class AddOrEditBooksActivity extends AppCompatActivity
 
         if (this.editingBook)
         {
-            if (Arrays.asList(
-                    Status.bPending,
-                    Status.Borrowed,
-                    Status.rPending).contains(bookToEdit.getStatus()))
-            {
-                deleteButton.setVisibility(View.GONE);
-            }
-            else
-            {
-                deleteButton.setVisibility(View.VISIBLE);
-            }
             /* Hide delete button if the book has no image url*/
             if (bookToEdit.getImageUrl().equals(""))
             {
@@ -222,6 +213,24 @@ public class AddOrEditBooksActivity extends AppCompatActivity
      */
     public void saveBook(View view)
     {
+        /* Disable saving changes if book is not available */
+        if (this.editingBook
+                && Arrays.asList(Status.Requested,
+                                    Status.Accepted,
+                                    Status.bPending,
+                                    Status.Borrowed,
+                                    Status.rPending).contains(bookToEdit.getStatus()))
+        {
+            Toast toast = Toast.makeText(AddOrEditBooksActivity.this, getString(R.string.cannot_edit_book), Toast.LENGTH_LONG);
+            toast.setGravity(Gravity.CENTER_VERTICAL|Gravity.CENTER_HORIZONTAL, 0,0);
+            ViewGroup group = (ViewGroup) toast.getView();
+            TextView messageTextView = (TextView) group.getChildAt(0);
+            messageTextView.setTextSize(18);
+            toast.show();
+            return;
+        }
+
+        /* Save changes */
         firebaseAuth = FirebaseAuth.getInstance();
         String title, author, description, isbn;
 

--- a/app/src/main/java/com/example/bookwormadventuresdeluxe2/Fragments/DetailView/BorrowDetailViewFragment.java
+++ b/app/src/main/java/com/example/bookwormadventuresdeluxe2/Fragments/DetailView/BorrowDetailViewFragment.java
@@ -20,13 +20,13 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.fragment.app.Fragment;
 
+import com.example.bookwormadventuresdeluxe2.Activities.Location.SetLocationActivity;
+import com.example.bookwormadventuresdeluxe2.Activities.Location.ViewLocationActivity;
 import com.example.bookwormadventuresdeluxe2.Models.Book;
 import com.example.bookwormadventuresdeluxe2.R;
-import com.example.bookwormadventuresdeluxe2.Activities.Location.SetLocationActivity;
 import com.example.bookwormadventuresdeluxe2.Utilities.NotificationUtility.NotificationHandler;
 import com.example.bookwormadventuresdeluxe2.Utilities.Status;
 import com.example.bookwormadventuresdeluxe2.Utilities.UserCredentialAPI;
-import com.example.bookwormadventuresdeluxe2.Activities.Location.ViewLocationActivity;
 import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
@@ -102,12 +102,27 @@ public class BorrowDetailViewFragment extends DetailView
             {
                 if (snapshot != null && snapshot.exists())
                 {
-                    selectedBook = snapshot.toObject(Book.class);
-                    Activity activity = getActivity();
-                    if (isAdded() && activity != null)
+                    if (BorrowDetailViewFragment.this.isVisible()
+                        && selectedBook.getRequesters().contains(UserCredentialAPI.getInstance().getUsername())
+                        && !snapshot.toObject(Book.class).getRequesters().contains(UserCredentialAPI.getInstance().getUsername()))
                     {
-                        redraw();
+                        closeFragment(BorrowDetailViewFragment.this, getString(R.string.request_denied_message));
                     }
+                    else
+                    {
+                        /* Update book */
+                        selectedBook = snapshot.toObject(Book.class);
+                        Activity activity = getActivity();
+                        if (isAdded() && activity != null)
+                        {
+                            redraw();
+                        }
+                    }
+                }
+                else if (BorrowDetailViewFragment.this.isVisible())
+                {
+                    /* Close fragment if book is deleted */
+                    closeFragment(BorrowDetailViewFragment.this, getString(R.string.book_deleted_message));
                 }
             }
         });

--- a/app/src/main/java/com/example/bookwormadventuresdeluxe2/Fragments/DetailView/BorrowDetailViewFragment.java
+++ b/app/src/main/java/com/example/bookwormadventuresdeluxe2/Fragments/DetailView/BorrowDetailViewFragment.java
@@ -102,6 +102,7 @@ public class BorrowDetailViewFragment extends DetailView
             {
                 if (snapshot != null && snapshot.exists())
                 {
+                    /* Close fragment if request is denied by owner */
                     if (BorrowDetailViewFragment.this.isVisible()
                         && selectedBook.getRequesters().contains(UserCredentialAPI.getInstance().getUsername())
                         && !snapshot.toObject(Book.class).getRequesters().contains(UserCredentialAPI.getInstance().getUsername()))

--- a/app/src/main/java/com/example/bookwormadventuresdeluxe2/Fragments/DetailView/DetailView.java
+++ b/app/src/main/java/com/example/bookwormadventuresdeluxe2/Fragments/DetailView/DetailView.java
@@ -189,6 +189,12 @@ public abstract class DetailView extends Fragment
         });
     }
 
+    /**
+     * Closes fragment
+     *
+     * @param fragment Fragment to be closed
+     * @param message  Reason for closing fragment
+     */
     protected void closeFragment(Fragment fragment, String message)
     {
         Fragment activeFragment = ActiveFragmentTracker.activeFragment;
@@ -199,6 +205,5 @@ public abstract class DetailView extends Fragment
         TextView messageTextView = (TextView) group.getChildAt(0);
         messageTextView.setTextSize(18);
         toast.show();
-
     }
 }

--- a/app/src/main/java/com/example/bookwormadventuresdeluxe2/Fragments/DetailView/DetailView.java
+++ b/app/src/main/java/com/example/bookwormadventuresdeluxe2/Fragments/DetailView/DetailView.java
@@ -197,6 +197,9 @@ public abstract class DetailView extends Fragment
      */
     protected void closeFragment(Fragment fragment, String message)
     {
+        /*
+         * Source: https://stackoverflow.com/questions/5274354/how-can-we-increase-the-font-size-in-toast
+         * */
         Fragment activeFragment = ActiveFragmentTracker.activeFragment;
         getFragmentManager().beginTransaction().remove(fragment).show(activeFragment).commit();
         Toast toast = Toast.makeText(getActivity(), message, Toast.LENGTH_LONG);

--- a/app/src/main/java/com/example/bookwormadventuresdeluxe2/Fragments/DetailView/DetailView.java
+++ b/app/src/main/java/com/example/bookwormadventuresdeluxe2/Fragments/DetailView/DetailView.java
@@ -8,6 +8,7 @@ package com.example.bookwormadventuresdeluxe2.Fragments.DetailView;
 
 import android.os.Build;
 import android.os.Bundle;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -15,6 +16,7 @@ import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.RequiresApi;
 import androidx.fragment.app.Fragment;
@@ -23,6 +25,7 @@ import com.example.bookwormadventuresdeluxe2.Fragments.NavigatonBar.ProfileFragm
 import com.example.bookwormadventuresdeluxe2.Models.Book;
 import com.example.bookwormadventuresdeluxe2.Models.User;
 import com.example.bookwormadventuresdeluxe2.R;
+import com.example.bookwormadventuresdeluxe2.Utilities.ActiveFragmentTracker;
 import com.example.bookwormadventuresdeluxe2.Utilities.FirebaseUserGetSet;
 import com.example.bookwormadventuresdeluxe2.Utilities.UserCredentialAPI;
 import com.google.zxing.integration.android.IntentIntegrator;
@@ -184,5 +187,18 @@ public abstract class DetailView extends Fragment
                 });
             }
         });
+    }
+
+    protected void closeFragment(Fragment fragment, String message)
+    {
+        Fragment activeFragment = ActiveFragmentTracker.activeFragment;
+        getFragmentManager().beginTransaction().remove(fragment).show(activeFragment).commit();
+        Toast toast = Toast.makeText(getActivity(), message, Toast.LENGTH_LONG);
+        toast.setGravity(Gravity.CENTER_VERTICAL|Gravity.CENTER_HORIZONTAL, 0,0);
+        ViewGroup group = (ViewGroup) toast.getView();
+        TextView messageTextView = (TextView) group.getChildAt(0);
+        messageTextView.setTextSize(18);
+        toast.show();
+
     }
 }

--- a/app/src/main/java/com/example/bookwormadventuresdeluxe2/Fragments/DetailView/RequestDetailViewFragment.java
+++ b/app/src/main/java/com/example/bookwormadventuresdeluxe2/Fragments/DetailView/RequestDetailViewFragment.java
@@ -97,15 +97,27 @@ public class RequestDetailViewFragment extends DetailView
             {
                 if (snapshot != null && snapshot.exists())
                 {
+                    /* Update book */
                     selectedBook = snapshot.toObject(Book.class);
-                    Activity activity = getActivity();
-                    if (isAdded() && activity != null)
+
+                    /* Close fragment if all requests are cancelled */
+                    if (selectedBook.getStatus().equals(Status.Available) && RequestDetailViewFragment.this.isVisible())
                     {
-                        redraw();
+                        closeFragment(RequestDetailViewFragment.this, getString(R.string.request_cancelled_message));
+                    }
+                    else
+                    {
+                        /* Draw new book */
+                        Activity activity = getActivity();
+                        if (isAdded() && activity != null)
+                        {
+                            redraw();
+                        }
                     }
                 }
             }
         });
+
         return bookDetailView;
     }
 
@@ -333,9 +345,7 @@ public class RequestDetailViewFragment extends DetailView
         switch (book.getStatus())
         {
             case Available:
-                user.setVisibility(View.GONE);
-                dropdownContainer.setVisibility(View.GONE);
-                status.setText(getString(R.string.available));
+                /* Never reached */
                 break;
             case Requested:
             case Accepted:

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,4 +163,10 @@
     <string name="hand_to_owner">Hand book to owner</string>
     <string name="unsuccessful_scan">Scan was unsuccessful</string>
 
+    <!-- Close Fragment Messager -->
+    <string name="request_denied_message">Book request denied</string>
+    <string name="request_cancelled_message">Book request cancelled</string>
+    <string name="book_deleted_message">Book deleted</string>
+    <string name="cannot_edit_book">Cannot edit book</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -166,7 +166,6 @@
     <!-- Close Fragment Messager -->
     <string name="request_denied_message">Book request denied</string>
     <string name="request_cancelled_message">Book request cancelled</string>
-    <string name="book_deleted_message">Book deleted</string>
-    <string name="cannot_edit_book">Cannot edit book</string>
+    <string name="book_deleted_message">Book deleted by owner</string>
 
 </resources>


### PR DESCRIPTION
*closing detail fragment if
   -book is deleted
   -request is cancelled
   -request is denied

*disable edit save changes button if
   -book is not available

*re-enable deleting books with any status
    (prof specification =/)

![image](https://user-images.githubusercontent.com/39696855/100534266-33f85680-31ca-11eb-9f3e-bcdae8612e67.png)
![image](https://user-images.githubusercontent.com/39696855/100534277-4a9ead80-31ca-11eb-872b-b671592c0946.png)
![image](https://user-images.githubusercontent.com/39696855/100534285-5c805080-31ca-11eb-9898-664e1a0134f1.png)
![image](https://user-images.githubusercontent.com/39696855/100534289-6904a900-31ca-11eb-8ba0-49f7a5b9c80c.png)



